### PR TITLE
Allow direct instance connect to slot or function pointers. 

### DIFF
--- a/rocket.hpp
+++ b/rocket.hpp
@@ -3362,6 +3362,78 @@ namespace rocket
                 return R((*Method)(args...));
             }, flags);
         }
+        
+        template <class Instance>
+        connection connect(Instance& object, slot_type slot, connection_flags flags = direct_connection)
+        {
+            connection c{
+                connect(slot)
+            };
+            if constexpr (std::is_convertible_v<Instance*, trackable*>) {
+                static_cast<trackable&>(object).add_tracked_connection(c);
+            }
+            return c;
+        }
+        
+        template <class Instance, class R1, class... Args1>
+        connection connect(Instance& object, R1(*method)(Args1...), connection_flags flags = direct_connection)
+        {
+            connection c{
+                connect(method)
+            };
+            if constexpr (std::is_convertible_v<Instance*, trackable*>) {
+                static_cast<trackable&>(object).add_tracked_connection(c);
+            }
+            return c;
+        }
+        
+        template <class Instance>
+        connection connect(Instance& object, connection_flags flags = direct_connection)
+        {
+            connection c{
+                connect()
+            };
+            if constexpr (std::is_convertible_v<Instance*, trackable*>) {
+                static_cast<trackable&>(object).add_tracked_connection(c);
+            }
+            return c;
+        }
+        
+        template <class Instance>
+        connection connect(Instance* object, slot_type slot, connection_flags flags = direct_connection)
+        {
+            connection c{
+                connect(slot)
+            };
+            if constexpr (std::is_convertible_v<Instance*, trackable*>) {
+                static_cast<trackable*>(object)->add_tracked_connection(c);
+            }
+            return c;
+        }
+        
+        template <class Instance, class R1, class... Args1>
+        connection connect(Instance* object, R1(*method)(Args1...), connection_flags flags = direct_connection)
+        {
+            connection c{
+                connect(method)
+            };
+            if constexpr (std::is_convertible_v<Instance*, trackable*>) {
+                static_cast<trackable*>(object)->add_tracked_connection(c);
+            }
+            return c;
+        }
+        
+        template <class Instance>
+        connection connect(Instance* object, connection_flags flags = direct_connection)
+        {
+            connection c{
+                connect()
+            };
+            if constexpr (std::is_convertible_v<Instance*, trackable*>) {
+                static_cast<trackable*>(object)->add_tracked_connection(c);
+            }
+            return c;
+        }
 
         template <class Instance, class Class, class R1, class... Args1>
         connection connect(Instance& object, R1(Class::*method)(Args1...), connection_flags flags = direct_connection)


### PR DESCRIPTION
While integrating this project into my projects I found the need to write calls like this:
```cpp
axis->OnAxis().connect(this, [this](float value) {
	onAxis(GetAmount());
});
```