### PR TITLE
Update rocket.hpp

### DIFF
--- a/rocket.hpp
+++ b/rocket.hpp
@@ -2082,8 +2082,8 @@ namespace rocket
 
             bool is_queued() const ROCKET_NOEXCEPT
             {
-                return thread_id != std::thread::id{}
-                && thread_id != std::this_thread::get_id();
+                return !(thread_id == std::thread::id{})
+                && !(thread_id == std::this_thread::get_id());
             }
 
 #ifndef ROCKET_NO_BLOCKING_CONNECTIONS


### PR DESCRIPTION
compilation error in rocket.hpp with gcc 11.3.0 (under ubuntu 22) with C++20 because operator!= (like all other secondary operators) has been removed in C++20: https://en.cppreference.com/w/cpp/thread/thread/id

simple fix is to use the primary operator== instead